### PR TITLE
Fix CI workflow for our fork

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -16,9 +16,12 @@ name: "Develop"
 
 on:
   # Trigger the workflow on push to develop
-  push:
-    branches:
-      - develop
+  #push:
+  #  branches:
+  #    - develop
+
+  # Disabled automatic trigger - use fork_develop.yml for CI in fork
+  workflow_dispatch:
 
 jobs:
   job_run_unit_tests_previous_versions:

--- a/.github/workflows/fork_develop.yml
+++ b/.github/workflows/fork_develop.yml
@@ -1,0 +1,33 @@
+# Copyright 2022 RTDIP
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Fork Develop - Lint and Test"
+
+on:
+  # Trigger the workflow on push to develop
+  push:
+    branches:
+      - develop
+  # Also allow manual trigger
+  workflow_dispatch:
+
+jobs:
+  # Run linting and tests using the upstream workflow
+  # This includes:
+  # - Black code formatting check (linting)
+  # - Unit tests across multiple Python versions (3.9-3.12)
+  # - Unit tests across multiple PySpark versions (3.3.0-3.5.1)
+  # - Documentation build test
+  job_lint_and_test:
+    uses: rtdip/core/.github/workflows/test.yml@develop


### PR DESCRIPTION
- Modified .github/workflows/develop.yml to only run manually (workflow_dispatch)
- Added .github/workflows/fork_develop.yml with simplified workflow that:
  - Runs Black linting
  - Runs unit tests across Python 3.9-3.12
  - Runs unit tests across PySpark 3.3.0-3.5.1
  - Tests documentation build